### PR TITLE
feat: add project sprint listing controller

### DIFF
--- a/src/sprint/project-sprint.controller.ts
+++ b/src/sprint/project-sprint.controller.ts
@@ -1,0 +1,32 @@
+import {
+  ClassSerializerInterceptor,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Req,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common'
+import { SprintService } from './sprint.service'
+import { RolesGuard } from '../auth/roles.guard'
+import { ResponseSprintDto } from './dto/response-sprint.dto'
+import { Roles } from '../auth/roles.decorator'
+
+@Controller('projects/:projectId/sprints')
+@UseGuards(RolesGuard)
+@UseInterceptors(ClassSerializerInterceptor)
+export class ProjectSprintController {
+  constructor(private readonly sprintService: SprintService) {}
+
+  @Get()
+  @Roles('admin', 'director', 'developer', 'tester', 'devOps')
+  async listByProject(
+    @Req() req: any,
+    @Param('projectId', ParseIntPipe) projectId: number,
+  ): Promise<ResponseSprintDto[]> {
+    const sprints = await this.sprintService.listByProject(req.user, projectId)
+
+    return sprints.map((sprint) => new ResponseSprintDto(sprint))
+  }
+}

--- a/src/sprint/sprint.module.ts
+++ b/src/sprint/sprint.module.ts
@@ -3,13 +3,14 @@ import { TypeOrmModule } from '@nestjs/typeorm'
 import { Sprint } from './sprint.entity'
 import { SprintService } from './sprint.service'
 import { SprintController } from './sprint.controller'
+import { ProjectSprintController } from './project-sprint.controller'
 import { Project } from '../project/project.entity'
 import { Task } from '../task/task.entity';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Sprint, Project, Task])],
   providers: [SprintService],
-  controllers: [SprintController],
+  controllers: [SprintController, ProjectSprintController],
   exports: [SprintService],
 })
 export class SprintModule {}


### PR DESCRIPTION
## Summary
- add a dedicated controller for `projects/:projectId/sprints` that reuses the existing guards and response dto
- register the new controller in `SprintModule` while keeping the legacy `/sprints/project/:projectId` handler

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc5bbdeb248324ad8ae8c9752145a9