### PR TITLE
Add meeting listing endpoint for project

### DIFF
--- a/src/meeting/dto/meeting-response.dto.ts
+++ b/src/meeting/dto/meeting-response.dto.ts
@@ -1,0 +1,17 @@
+export class MeetingUserDto {
+  id: number;
+  firstName: string;
+  lastName: string;
+  email: string;
+}
+
+export class MeetingResponseDto {
+  id: number;
+  title: string;
+  scheduledAt: Date;
+  notes: string | null;
+  location: string | null;
+  agenda: string;
+  createdBy: MeetingUserDto | null;
+  participants: MeetingUserDto[];
+}

--- a/src/meeting/meeting.controller.ts
+++ b/src/meeting/meeting.controller.ts
@@ -1,8 +1,9 @@
-import { Body, Controller, Param, Post, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Req, UseGuards } from '@nestjs/common';
 import { RolesGuard } from '../auth/roles.guard';
 import { MeetingService } from './meeting.service';
 import { CreateMeetingDto } from './dto/create-meeting.dto';
 import { Request } from 'express';
+import { MeetingResponseDto } from './dto/meeting-response.dto';
 
 @Controller('projects/:projectId/meetings')
 @UseGuards(RolesGuard)
@@ -16,5 +17,13 @@ export class MeetingController {
     @Req() req: Request,
   ) {
     return this.meetingService.createMeeting(+projectId, createMeetingDto, req.user as any);
+  }
+
+  @Get()
+  async getProjectMeetings(
+    @Param('projectId') projectId: string,
+    @Req() req: Request,
+  ): Promise<MeetingResponseDto[]> {
+    return this.meetingService.findByProject(+projectId, req.user as any);
   }
 }


### PR DESCRIPTION
## Summary
- add a GET handler on the meeting controller to serve project meeting listings
- implement meeting service logic to validate membership and return meeting details including creators and participants
- introduce a meeting response DTO to shape the returned meeting data

## Testing
- npm run lint *(fails: pre-existing lint errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5bbc6dd88324872fa9da536e5f5f