### PR TITLE
Add secure auth cookie support

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,13 +1,14 @@
-import { Body, Controller, Post, Res } from '@nestjs/common';
+import { Body, Controller, Post, Get, Req, Res } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { UserService } from '../user/user.service';
 import { CreateUserDto } from '../user/dto/create-user.dto';
 import { LoginDto } from './dto/login.dto';
-import type { Response } from 'express';
+import type { Request, Response } from 'express';
 import {
   AUTH_COOKIE_NAME,
   buildAuthCookieOptions,
 } from '../common/constants/auth.constants';
+import * as jwt from 'jsonwebtoken';
 
 @Controller('auth')
 export class AuthController {
@@ -22,8 +23,22 @@ export class AuthController {
     @Res({ passthrough: true }) res: Response,
   ) {
     const response = await this.authService.validateUser(loginDto);
+
+    // 🍪 Cookie set et
     res.cookie(AUTH_COOKIE_NAME, response.token, buildAuthCookieOptions());
-    return response;
+
+    // user bilgisi de dönüyoruz (frontend UI için)
+    const decoded: any = jwt.decode(response.token);
+    return {
+      message: response.message,
+      expiresAt: response.expiresAt,
+      user: {
+        id: decoded.id,
+        firstName: decoded.firstName,
+        lastName: decoded.lastName,
+        role: decoded.role,
+      },
+    };
   }
 
   @Post('register')
@@ -35,5 +50,38 @@ export class AuthController {
 
     await this.usersService.create(createUserDto);
     return { message: 'Kayıt başarılı' };
+  }
+
+  // ✅ Kullanıcı bilgilerini döndürür (cookie’den token'ı okuyarak)
+  @Get('me')
+  async me(@Req() req: Request) {
+    const token = req.cookies?.[AUTH_COOKIE_NAME];
+    if (!token) {
+      return { user: null };
+    }
+
+    try {
+      const decoded: any = jwt.verify(token, process.env.JWT_SECRET as string);
+      return {
+        user: {
+          id: decoded.id,
+          name: `${decoded.firstName} ${decoded.lastName}`,
+          role: decoded.role,
+        },
+      };
+    } catch (err) {
+      console.error('JWT doğrulama hatası:', err);
+      return { user: null };
+    }
+  }
+
+  // ✅ Logout (cookie'yi sıfırlar)
+  @Post('logout')
+  async logout(@Res({ passthrough: true }) res: Response) {
+    res.cookie(AUTH_COOKIE_NAME, '', {
+      ...buildAuthCookieOptions(),
+      maxAge: 0,
+    });
+    return { message: 'Çıkış başarılı' };
   }
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,8 +1,13 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Body, Controller, Post, Res } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { UserService } from '../user/user.service';
 import { CreateUserDto } from '../user/dto/create-user.dto';
 import { LoginDto } from './dto/login.dto';
+import type { Response } from 'express';
+import {
+  AUTH_COOKIE_NAME,
+  buildAuthCookieOptions,
+} from '../common/constants/auth.constants';
 
 @Controller('auth')
 export class AuthController {
@@ -12,8 +17,13 @@ export class AuthController {
   ) {}
 
   @Post('login')
-  async login(@Body() loginDto: LoginDto) {
-    return this.authService.validateUser(loginDto);
+  async login(
+    @Body() loginDto: LoginDto,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const response = await this.authService.validateUser(loginDto);
+    res.cookie(AUTH_COOKIE_NAME, response.token, buildAuthCookieOptions());
+    return response;
   }
 
   @Post('register')

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -4,6 +4,7 @@ import * as jwt from 'jsonwebtoken';
 import { UserService } from '../user/user.service';
 import { ResponseLoginDto } from './dto/response-login.dto';
 import { LoginDto } from './dto/login.dto';
+import { getAuthTokenTtlSeconds } from '../common/constants/auth.constants';
 
 @Injectable()
 export class AuthService {
@@ -23,6 +24,7 @@ export class AuthService {
     }
 
     // JWT token oluştur
+    const expiresInSeconds = getAuthTokenTtlSeconds();
     const token = jwt.sign(
       {
         id: user.id,
@@ -31,13 +33,15 @@ export class AuthService {
         lastName: user.lastName
       },
       process.env.JWT_SECRET as string,
-      { expiresIn: '2h' }
+      { expiresIn: expiresInSeconds }
     );
 
     // DTO olarak dön
     return {
       message: 'Giriş başarılı',
       token,
+      expiresIn: expiresInSeconds,
+      expiresAt: new Date(Date.now() + expiresInSeconds * 1000).toISOString(),
     };
   }
 }

--- a/src/auth/dto/response-login.dto.ts
+++ b/src/auth/dto/response-login.dto.ts
@@ -7,4 +7,10 @@ export class ResponseLoginDto {
 
   @Expose()
   token: string;
+
+  @Expose()
+  expiresIn: number;
+
+  @Expose()
+  expiresAt: string;
 }

--- a/src/auth/roles.guard.ts
+++ b/src/auth/roles.guard.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import * as jwt from 'jsonwebtoken';
+import { extractTokenFromRequest } from './utils/auth-token.util';
 
 @Injectable()
 export class RolesGuard implements CanActivate {
@@ -15,18 +16,9 @@ export class RolesGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean {
     const request = context.switchToHttp().getRequest();
 
-    // 1. Authorization header'ını al (case-insensitive)
-    const authHeader =
-      request.headers['authorization'] ||
-      request.headers['Authorization'];
-
-    if (!authHeader || typeof authHeader !== 'string' || !authHeader.startsWith('Bearer ')) {
-      throw new UnauthorizedException('Authorization header eksik veya hatalı');
-    }
-
-    const token = authHeader.split(' ')[1];
+    const token = extractTokenFromRequest(request);
     if (!token) {
-      throw new UnauthorizedException('Token alınamadı');
+      throw new UnauthorizedException('Authorization bilgisi alınamadı');
     }
 
     // 2. JWT doğrula ve kullanıcıyı ekle

--- a/src/auth/utils/auth-token.util.ts
+++ b/src/auth/utils/auth-token.util.ts
@@ -1,0 +1,79 @@
+import type { Request } from 'express';
+import { AUTH_COOKIE_NAME } from '../../common/constants/auth.constants';
+
+type HeadersLike = Record<string, unknown> | undefined;
+
+type RequestLike = Partial<Request> & {
+  headers?: HeadersLike;
+  cookies?: Record<string, string>;
+};
+
+const getHeaderValue = (headers: HeadersLike, key: string): string | undefined => {
+  if (!headers) return undefined;
+  const direct = headers[key];
+  if (typeof direct === 'string') {
+    return direct;
+  }
+
+  const lowerKey = key.toLowerCase();
+  for (const headerName of Object.keys(headers)) {
+    if (headerName.toLowerCase() === lowerKey) {
+      const value = headers[headerName];
+      if (typeof value === 'string') {
+        return value;
+      }
+      if (Array.isArray(value)) {
+        return value[0];
+      }
+    }
+  }
+  return undefined;
+};
+
+const parseCookieHeader = (cookieHeader?: string): Record<string, string> => {
+  if (!cookieHeader) return {};
+
+  return cookieHeader.split(';').reduce<Record<string, string>>((acc, raw) => {
+    const [name, ...rest] = raw.split('=');
+    if (!name) return acc;
+    const value = rest.join('=').trim();
+    if (!value) return acc;
+    acc[name.trim()] = decodeURIComponent(value);
+    return acc;
+  }, {});
+};
+
+const extractBearerToken = (authorizationHeader?: string): string | undefined => {
+  if (!authorizationHeader || typeof authorizationHeader !== 'string') {
+    return undefined;
+  }
+  if (!authorizationHeader.startsWith('Bearer ')) {
+    return undefined;
+  }
+  const token = authorizationHeader.slice(7).trim();
+  return token.length > 0 ? token : undefined;
+};
+
+export const extractTokenFromRequest = (request: RequestLike): string | undefined => {
+  const authorization = getHeaderValue(request.headers, 'authorization');
+  const fromHeader = extractBearerToken(authorization);
+  if (fromHeader) {
+    return fromHeader;
+  }
+
+  const fromCookies = request.cookies?.[AUTH_COOKIE_NAME];
+  if (fromCookies && typeof fromCookies === 'string' && fromCookies.length > 0) {
+    return fromCookies;
+  }
+
+  const cookieHeader = getHeaderValue(request.headers, 'cookie');
+  if (cookieHeader) {
+    const parsed = parseCookieHeader(cookieHeader);
+    const candidate = parsed[AUTH_COOKIE_NAME];
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+};

--- a/src/common/constants/auth.constants.ts
+++ b/src/common/constants/auth.constants.ts
@@ -1,0 +1,48 @@
+import type { CookieOptions } from 'express';
+
+export const AUTH_COOKIE_NAME = 'everup_auth_token';
+const DEFAULT_TOKEN_TTL_SECONDS = 2 * 60 * 60; // 2 saat
+
+const parsePositiveNumber = (value?: string): number | undefined => {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+  return undefined;
+};
+
+export const getAuthTokenTtlSeconds = (): number => {
+  const fromEnv =
+    parsePositiveNumber(process.env.JWT_EXPIRES_IN_SECONDS) ??
+    parsePositiveNumber(process.env.JWT_EXPIRES_IN) ??
+    parsePositiveNumber(process.env.JWT_TTL_SECONDS);
+
+  return fromEnv ?? DEFAULT_TOKEN_TTL_SECONDS;
+};
+
+export const buildAuthCookieOptions = (): CookieOptions => {
+  const secure =
+    process.env.AUTH_COOKIE_SECURE === 'true' ||
+    process.env.NODE_ENV === 'production';
+
+  const sameSiteEnv = (process.env.AUTH_COOKIE_SAMESITE ?? '').toLowerCase();
+  let sameSite: CookieOptions['sameSite'];
+  if (sameSiteEnv === 'lax' || sameSiteEnv === 'strict') {
+    sameSite = sameSiteEnv;
+  } else if (sameSiteEnv === 'none') {
+    sameSite = 'none';
+  } else {
+    sameSite = secure ? 'none' : 'lax';
+  }
+
+  const maxAge = getAuthTokenTtlSeconds() * 1000;
+
+  return {
+    httpOnly: true,
+    secure,
+    sameSite,
+    maxAge,
+    path: '/',
+  };
+};


### PR DESCRIPTION
## Summary
- issue login responses with httpOnly, secure, same-site cookies configured via shared helpers
- expose expiry metadata on login responses and reuse the TTL for JWT creation
- allow HTTP guards and the voice gateway to read tokens from either headers or cookies

## Testing
- npm test -- --passWithNoTests
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68eb5f5c698083248e9032fa96b1dc10